### PR TITLE
Delete username/password from session on logout

### DIFF
--- a/controllers/logout.go
+++ b/controllers/logout.go
@@ -8,8 +8,8 @@ import (
 
 func Logout(w http.ResponseWriter, r *http.Request) {
 	session, _ := utils.GetCookieStore(r).Get(r, "sirsid")
-	session.Values["username"] = ""
-	session.Values["password"] = ""
+	delete(session.Values, "username")
+	delete(session.Values, "password")
 
 	err := session.Save(r, w)
 	if err != nil {


### PR DESCRIPTION
I was seeing this error sometimes (i.e. after logging out):

```
[error] Cannot select user (sql: no rows in result set)
```

AuthenticateUser was getting called with empty strings for username password, because the logout function was setting them as such. So here it is changed to delete them from the session map, so they are nil and we don't try to authenticate them.
